### PR TITLE
support stop_grace_period in launched container

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -79,6 +79,7 @@ if [ -f ${COMPOSE_FILE} ]; then
     'LAUNCH_SYSCTLS'
     'LAUNCH_COMMAND'
     'LAUNCH_CGROUP_PARENT'
+    'LAUNCH_STOP_GRACE_PERIOD'
   )
   for LAUNCH_VARIABLE in "${LAUNCH_VARIABLES[@]}"; do
     if [ -n "${!LAUNCH_VARIABLE}" ]; then
@@ -225,6 +226,11 @@ xEOF
         } >> ${COMPOSE_FILE}
       done
     fi
+  fi
+
+  # stop grace period
+  if [ -n "${LAUNCH_STOP_GRACE_PERIOD}" ]; then
+    echo "    stop_grace_period: ${LAUNCH_STOP_GRACE_PERIOD}" >> ${COMPOSE_FILE}
   fi
 fi
 


### PR DESCRIPTION
I have some containers that execute long-running jobs, and I would like them to be able to finish, rather than have docker kill the container after the default 10 seconds.  E.g., if a job typically takes 10 minutes to run, and a job has been running for 9m40s when the service is stopped or updated, I want to let it finish.

Note that when the new the LAUNCH_STOP_GRACE_PERIOD option is specified, "stop_grace_period: <duration>" also needs to be added to the stack.yml file, assuming you want the swarm-launcher container to stick around until the launched container stops.  And the duration specified in the yaml file should be slightly longer than the LAUNCH_STOP_GRACE_PERIOD value.