### PR TITLE
Global substitution for `@_@` in `LAUNCH_ENVIRONMENTS`

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -144,7 +144,7 @@ xEOF
     echo "    environment:" >> ${COMPOSE_FILE}
     read -ra ARR <<<"${LAUNCH_ENVIRONMENTS}"
     for ENVIRONMENT in "${ARR[@]}"; do
-      echo "      - ${ENVIRONMENT/@_@/' '}" >> ${COMPOSE_FILE}
+      echo "      - ${ENVIRONMENT//@_@/' '}" >> ${COMPOSE_FILE}
     done
   fi
 


### PR DESCRIPTION
Hello,

The current implementation only replaces the first `@_@` with ` `. This modification allows the modification to be global.