### PR TITLE
Support for SECURITY_OPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The following environment variables are important if you don't supply a `/docker
 | `LAUNCH_EXT_NETWORKS`   | -                          | NO            | Space separated list of external networks to attach to |
 | `LAUNCH_CAP_ADD`        | -                          | NO            | Space separated list of capabilities to add |
 | `LAUNCH_CAP_DROP`       | -                          | NO            | Space separated list of capabilities to drop |
+| `LAUNCH_SECURITY_OPT    | -                          | NO            | Space separated list of security options to add |
 | `LAUNCH_LABELS`         | `ai.ix.started-by=ix.ai/swarm-launcher` | NO | Space separated list of Label=Value pairs |
 | `LAUNCH_PULL`           | `false`                    | NO            | Set this to `true` to check at every container start for the latest image version |
 | `LAUNCH_SYSCTLS`        | -                          | NO            | Space separated list of sysctl=value |

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Either way, `swarm-launcher` takes care of the setup, tear-down and cleanup of t
 
 See [Docs](docs/) and [Usage Examples](docs/usage_examples)
 
+## Building the image
+
+```
+docker build -t swarm-launcher .
+```
+
 ## Environment variables
 
 The following environment variables are important, if you plan on using a private repository:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -73,6 +73,7 @@ if [ -f ${COMPOSE_FILE} ]; then
     'LAUNCH_EXT_NETWORKS'
     'LAUNCH_CAP_ADD'
     'LAUNCH_CAP_DROP'
+    'LAUNCH_SECURITY_OPT'
     'LAUNCH_LABELS'
     'LAUNCH_PULL'
     'LAUNCH_SYSCTLS'
@@ -177,6 +178,14 @@ xEOF
     echo "    cap_drop:" >> ${COMPOSE_FILE}
     for CAP in ${LAUNCH_CAP_DOP}; do
       echo "      - ${CAP}" >> ${COMPOSE_FILE}
+    done
+  fi
+
+  # Security opt
+  if [ -n "${LAUNCH_SECURITY_OPT}" ]; then
+    echo "    security_opt:" >> ${COMPOSE_FILE}
+    for SECURITY_OPT in ${LAUNCH_SECURITY_OPT}; do
+      echo "      - ${SECURITY_OPT}" >> ${COMPOSE_FILE}
     done
   fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -250,7 +250,10 @@ if [ -n "${LOGIN_USER}" ] && [ -n "${LOGIN_PASSWORD}" ]; then
 fi
 
 # tests the config file
-_echo "Testing compose file"
+_echo "Testing compose file:"
+echo "-----------------------------------"
+cat ${COMPOSE_FILE}
+echo "-----------------------------------"
 docker-compose config
 
 # pull latest image version

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -251,9 +251,9 @@ fi
 
 # tests the config file
 _echo "Testing compose file:"
-echo "-----------------------------------"
+_echo "-----------------------------------"
 cat ${COMPOSE_FILE}
-echo "-----------------------------------"
+_echo "-----------------------------------"
 docker-compose config
 
 # pull latest image version


### PR DESCRIPTION
Hello,

Thank you for this project.

The main goal of this PR is to bring support for the **security_opt** flag: https://docs.docker.com/compose/compose-file/#security_opt

In the second commit I added some changes that I found nice to have:
- A copy/paste command to build the image
- Printing the content of the generated compose file, makes it easier to spot an issue if `docker-compose config` fails

Let me know what you think.